### PR TITLE
Add ignoring of the self-registration setting.

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -66,7 +66,7 @@ class RedmineOauthController < AccountController
    user = User.joins(:email_addresses).where(:email_addresses => { :address => info["email"] }).first_or_create
     if user.new_record?
       # Self-registration off
-      redirect_to(home_url) && return unless Setting.self_registration?
+      redirect_to(home_url) && return unless Setting.self_registration? || settings['ignore_self_registration']
       # Create on the fly
       user.firstname = info["family_name"]
       user.lastname = info["given_name"]

--- a/app/views/settings/_google_settings.html.erb
+++ b/app/views/settings/_google_settings.html.erb
@@ -14,3 +14,7 @@
   <label>Oauth authentification:</label>
   <%= check_box_tag "settings[oauth_authentification]", true, @settings['oauth_authentification'] %>
 </p>
+<p>
+  <label>Ignore self-registration setting:</label>
+  <%= check_box_tag "settings[ignore_self_registration]", true, @settings['ignore_self_registration'] %>
+</p>

--- a/init.rb
+++ b/init.rb
@@ -13,6 +13,7 @@ Redmine::Plugin.register :redmine_omniauth_google do
     :client_id => "",
     :client_secret => "",
     :oauth_autentification => false,
-    :allowed_domains => ""
+    :allowed_domains => "",
+    :ignore_self_registration => false
   }, :partial => 'settings/google_settings'
 end


### PR DESCRIPTION
Adds a new setting which allows to override the Redmine self_registration option and force a creation of a new account if the normal registration is disabled.

Tested on
```
  Redmine version                3.4.6.stable
  Ruby version                   2.3.3-p222 (2016-11-21) [x86_64-linux-gnu]
  Rails version                  4.2.8
```

Based on this pull request from root repository: https://github.com/twinslash/redmine_omniauth_google/pull/9